### PR TITLE
Typo in Stackage description (test -> tests)

### DIFF
--- a/src/HL/V/Downloads.hs
+++ b/src/HL/V/Downloads.hs
@@ -80,7 +80,7 @@ hackage =
 stackage =
   do h3 [] "Stackage"
      p [] "Stackage is a stable repository of snapshots of package sets in \
-          \which only packages which build and pass test together are bundled \
+          \which only packages which build and pass tests together are bundled \
           \together into a snapshot."
      p [] (do "To use, in your "
               code [] ".cabal/config"


### PR DESCRIPTION
I wanted to change it to "build and pass all tests together", but I didn't know if this is actually true. Maybe some packages fail certain tests that are known bugs or something.
