### PR TITLE
Use Fibonacci instead of Sieve for code sample

### DIFF
--- a/src/HL/V/Home.hs
+++ b/src/HL/V/Home.hs
@@ -63,9 +63,9 @@ header url =
 -- TODO: should be rotatable and link to some article.
 codeSample :: Text
 codeSample =
-  "primes = sieve [2..]\n\
-  \    where sieve (p:xs) = \n\
-  \      p : sieve [x | x <- xs, x `mod` p /= 0]"
+  "fibonacci 0 = 0\n\
+  \fibonacci 1 = 1\n\
+  \fibonacci n = fibonacci (n - 1) + fibonacci (n - 2)"
 
 -- | Try Haskell section.
 try :: (Route App -> AttributeValue) -> Senza


### PR DESCRIPTION
Arguments for this: (from the HN discussion)
- "Find the Nth Fibonacci Number" is among the most universally known programming tasks, so visitors are far more likely to immediately pick up the example than they are with sieve.
- It shows off a bit of Haskell syntax that (A) can be learned just by looking at an example like this, (B) has a clear benefit to readability that any programmer can appreciate, and (C) is a syntax not found in most mainstream languages.
- The visitor needs no functional programming experience to follow it; it doesn't even use any higher-order functions! This is important, as many visitors will be completely new to FP, and an example that they can't follow is not going to be effective at encouraging them to continue reading.
