### PR TITLE
Revert "Reword features section for the target audience."

### DIFF
--- a/src/HL/V/Home/Features.hs
+++ b/src/HL/V/Home/Features.hs
@@ -14,42 +14,74 @@ features =
   div [class_ "features"]
       (container
          (do h1 [] "Features"
-             row (do span6 [] nulls
-                     span6 [] concurrency)
-             row (do span6 [] inference
-                     span6 [] ecosystem)))
+             row (do span6 [] purefunc
+                     span6 [] statically)
+             row (do span6 [] concurrent
+                     span6 [] inference)
+             row (do span6 [] lazy
+                     span6 [] packages)))
 
-nulls :: Senza
-nulls =
-  do h2 [] "No More Null Errors"
-     p [] "How often do programs crash because of an unexpected null value? \
-          \Haskell programs never do! The compiler has your back; \
-          \it tells you anytime you forget to properly handle an optional value."
+-- TODO: Features: tart up the wording.
+--
+-- Note: these below are me writing out the facts, for myself, rather
+-- than putting in a way that newbies will understand. The intention
+-- is to put *something* here and then rewrite the bits below to be
+-- more "salesy" aand friendly to people who have no idea what's so
+-- special about "IO" from any other form of programming, or what a
+-- parallel GC is or unification.
+
+purefunc :: Senza
+purefunc =
+  do h2 [] "Purely functional"
+     p [] "Every function in Haskell is pure. They are functions in the mathematical sense. \
+          \Even side-effecting IO operations are but a description of what to do, produced \
+          \by pure code. There are no statements or instructions, only expressions. Which \
+          \cannot mutate variables, local or global, or access state like time or random \
+          \numbers."
      p [] (a [] "View examples")
 
-concurrency :: Senza
-concurrency =
-  do h2 [] "Scaling Just Works"
-     p [] "You shouldn't have to rewrite half your code base when it's time to scale. \
-          \Haskell code is thread-safe by default, and the runtime efficiently handles concurrency for you. \
-          \Software transactional memory comes standard."
+statically :: Senza
+statically =
+  do h2 [] "Statically typed"
+     p [] "Every expression in Haskell has a type which is determined at compile time. \
+          \All the types composed together by function application have to match up. If \
+          \they don't, the program will be rejected by the compiler. Types become not \
+          \only a form of guarantee, but a language for expressing the construction \
+          \of programs."
+     p [] (a [] "View examples")
+
+concurrent :: Senza
+concurrent =
+  do h2 [] "Concurrent"
+     p [] "Haskell lends itself well to concurrent programming due to its explicit \
+          \handling of effects. Its flagship compiler, GHC, comes with a high-\
+          \performance parallel garbage collector and light-weight concurrency \
+          \library containing a number of useful concurrency primitives and \
+          \abstractions."
      p [] (a [] "View examples")
 
 inference :: Senza
 inference =
-  do h2 [] "Concise and Reliable: Pick Two"
-     p [] "What if you didn't have to write out type signatures, \
-          \but the compiler still caught all your type errors for you ahead of time? \
-          \Haskell's type inference ensures your logs remain completely free \
-          \of type errors, while you write signatures—or have the compiler write them for you—\
-          \only if you think they'll be helpful."
+  do h2 [] "Type inference"
+     p [] "You don't have to explicitly write out every type in a Haskell program. \
+          \Types will be inferred by unifying every type bidirectionally. But you \
+          \can write out types, or ask the compiler to write them for you, for \
+          \handy documentation."
      p [] (a [] "View examples")
 
-ecosystem :: Senza
-ecosystem =
-  do h2 [] "Rock-Solid Ecosystem"
-     p [] "Haskell code has a reputation: if it compiles, it usually just works. \
-          \Bugs are fewer and farther between. \
-          \Hackage hosts thousands of such libraries and packages, \
-          \any of which you can add to your project with one line of configuration."
+lazy :: Senza
+lazy =
+  do h2 [] "Lazy"
+     p [] "Functions don't evaluate their arguments. This means that programs \
+          \can compose together very well, with the ability to write control \
+          \constructs with normal functions, and, thanks also to the purity \
+          \of Haskell, to fuse chains of functions together for high \
+          \performance."
+     p [] (a [] "View examples")
+
+packages :: Senza
+packages =
+  do h2 [] "Packages"
+     p [] "Open source contribution to Haskell is very active with a wide range \
+          \of packages available on the public package servers."
      p [] (a [] "View examples")


### PR DESCRIPTION
This reverts commit 3da9d6453eae14b8bd645004f6f96f22a2de7cbd.

This old text is not very marketingy but is technically accurate without overselling. Until I can come up with better text I think this will do as a better base.
