### PR TITLE
Experimental video description on click (works well on iPads)

### DIFF
--- a/src/HL/V.hs
+++ b/src/HL/V.hs
@@ -14,6 +14,7 @@ import Control.Monad as V
 import Data.Text as V (Text)
 import Prelude as V hiding (span,head,min,max,id,div)
 import Text.Blaze.Bootstrap as V
+import Text.Blaze.Extra as V
 import Text.Blaze.Html5 as V hiding (map,title,style,header)
 import Text.Blaze.Html5.Attributes as V hiding (span,summary,style,form,cite,label)
 import Yesod.Blaze as V

--- a/src/HL/V/Home.hs
+++ b/src/HL/V/Home.hs
@@ -7,8 +7,8 @@ module HL.V.Home where
 
 import HL.V hiding (list)
 import HL.V.Code
-import HL.V.Template
 import HL.V.Home.Features
+import HL.V.Template
 
 -- | Home view.
 homeV :: [(Text, Text, Text)] -> FromBlaze App
@@ -86,24 +86,26 @@ try _ =
 -- TOOD: Should contain a list of thumbnail videos. See mockup.
 community :: (Route App -> AttributeValue) -> [(Text, Text, Text)] -> Html
 community url vids =
-  do div ! class_ "community"
-         ! background url img_community_jpg $
-         (do container
-               (row
-                  (span8
-                         (do h1
-                                "An open source community effort for over 20 years"
-                             p ! class_ "learn-more" $
-                               (a ! href (url CommunityR) $
-                                  "Learn more")))))
-     div ! class_ "videos" $
-         (container (row (span12 (ul (forM_ vids vid)))))
+  div !# "community-wrapper" $
+    do div ! class_ "community"
+           ! background url img_community_jpg $
+         do container !# "tagline"  $ row $ span8 $ do
+              h1 "An open source community effort for over 20 years"
+              p ! class_ "learn-more" $
+                a ! href (url CommunityR) $
+                  "Learn more"
+            container !# "video-description"  $ row $ span8 $ do
+              h1 $ a !# "video-anchor" $
+                "<title here>"
+              p $ a !# "video-view" $
+                "View the video now →"
+       div ! class_ "videos" $
+           (container (row (span12 (ul (forM_ vids vid)))))
   where
     vid (n,u,thumb) =
-      li
-         (a !href (toValue u)
-            !title (toValue n)$
-            (img ! src (toValue thumb)))
+      li $
+        a !. "vid-thumbnail" ! href (toValue u) ! title (toValue n) $
+          img ! src (toValue thumb)
 
 -- | Events section.
 -- TODO: Take events section from Haskell News?

--- a/src/HL/V/Template.hs
+++ b/src/HL/V/Template.hs
@@ -69,7 +69,8 @@ skeleton ptitle innerhead innerbody bodyender mroute url =
          footer url mroute
          scripts url
                  [js_jquery_js
-                 ,js_bootstrap_min_js]
+                 ,js_bootstrap_min_js
+                 ,js_home_js]
          bodyender mroute url
     -- TODO: pop this in a config file later.
     analytics =

--- a/static/css/hl.css
+++ b/static/css/hl.css
@@ -168,6 +168,11 @@ overflow: hidden;
    Home page
    */
 
+.page-home #video-anchor {
+  color: #fff;
+  text-decoration: none;
+}
+
 .page-home .navbar-collapse {
   margin-left: -30px;
 }
@@ -413,9 +418,15 @@ overflow: hidden;
 }
 
 .page-home .videos li a {
-  padding: 3px;
+  padding: 4px;
   border: 1px solid #333;
   display: inline-block;
+}
+.page-home .videos li a.current {
+  border: 1px solid #2a6496;
+}
+.page-home .videos li a:active {
+  border: 1px solid #fff;
 }
 
 /* * * * * * * * * * * * * * * * * * * *

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -1,0 +1,37 @@
+// Main entry point
+$(function(){
+  setupVids();
+});
+
+// Setup hovering of video thumbnails
+function setupVids(){
+  var $community = $('.community');
+  var $videos = $('.videos');
+  var $tagline = $('#tagline');
+  var $videoDesc = $('#video-description');
+  var $videoAnchor = $('#video-anchor');
+  var $videoView = $('#video-view');
+  var originalBackground = $community.css('background');
+
+  $videoDesc.hide();
+  // To keep a consistent height between transitions
+  $videoDesc.css('height',$tagline.height());
+
+  $('.vid-thumbnail').each(function(){
+    var $this = $(this);
+    var title = $this.attr('title');
+    var href = $this.attr('href');
+    $this.click(select);
+    function select(){
+      $videos.find('.current').removeClass('current');
+      $this.addClass('current');
+      $videoAnchor.text(title);
+      $videoAnchor.attr('href',href);
+      $videoView.attr('href',href);
+      $tagline.hide();
+      $videoDesc.show();
+      $community.css('background','#111111');
+      return false;
+    }
+  });
+}


### PR DESCRIPTION
Not a priority to merge, just a UI tweak based on #3. Can view the deployed behaviour here: http://haskell-lang.org/

I tested it on my iPad, too. I initially made it react to hover, but that makes no sense for touch screens.

Uses some JavaScript for now. I can make it use Fay but the pull request would be substantially bigger.

Ping @radix.

![screenshot from 2014-09-26 19 27 59](https://cloud.githubusercontent.com/assets/11019/4424731/846bb87a-45a2-11e4-9a70-ab24664c3d35.png)