### PR TITLE
Change instructions to use sandboxes so new people don't get stuck

### DIFF
--- a/src/HL/V/Downloads.hs
+++ b/src/HL/V/Downloads.hs
@@ -86,8 +86,11 @@ stackage =
            ".cabal/config file, you specify something like the following:")
      pre "remote-repo: stackage:http://www.stackage.org/stackage/<the-snapshot-hash>"
      p "(Note: any other remote-repo line should be removed or commented out)."
-     p "After that, you can install a package by merely running: "
+     p "After that, you can install a package into a sandbox by merely running: "
      pre "$ cabal update \n\
+         \$ mkdir my-project
+         \$ cd my-project
+         \$ cabal sandbox init
          \$ cabal install the-package"
      p (a ! href "http://www.stackage.org/" $ "Go to Stackage →")
 

--- a/static/markdown/manual-install.md
+++ b/static/markdown/manual-install.md
@@ -42,6 +42,9 @@ You can now update your package set:
 
     $ cabal update
 
-And install packages:
+And install packages into a sandbox so it doesn't conflict with other projects:
 
+    $ mkdir my-project
+    $ cd my-project
+    $ cabal sandbox init
     $ cabal install the-package-name


### PR DESCRIPTION
Not using sandboxes causes a lot of new people to get stuck because they keep installing a bunch of stuff into the user package-db. If we're not going to explain global vs. user vs. sandbox, just tell them to use a sandbox as a playground for installing stuff.
