### PR TITLE
add ghc 7.8.4 install instructions for Fedora 21

### DIFF
--- a/static/markdown/linux-install.md
+++ b/static/markdown/linux-install.md
@@ -16,6 +16,17 @@ Steps to setup:
     cabal update
     cabal install alex happy
 
+### Fedora 21
+
+To install Haskell 7.8.4 from the unofficial repo (Fedora 22+ will include it in the official one):
+
+    sudo yum-config-manager --add-repo https://copr.fedoraproject.org/coprs/petersen/ghc-7.8.4/repo/fedora-21/petersen-ghc-7.8.4-fedora-21.repo
+    sudo yum install ghc cabal-install
+
+As stated in [petersen/ghc-7.8.4 copr page](https://copr.fedoraproject.org/coprs/petersen/ghc-7.8.4/) this ghc cannot be installed in parallel with Fedora/EPEL ghc.
+
+If you want to install from the official repo that uses an older version of ghc (7.6.x) and cabal-install (1.16.x), just run the install command without adding the unofficial repo.
+
 ### Arch Linux
 
 To install Haskell from the official repos on Arch Linux:


### PR DESCRIPTION
Since Fedora is a widely used distro there should be install instructions for it.