### PR TITLE
No submodules are required since #15.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,9 @@ You need the right package set. Add the following to your
 
 Now just run:
 
-    $ git submodule init
     $ sh scripts/pull-build
 
-To do the cabal update, submodule, install, etc.
+To do the cabal update, install, etc.
 
 Done!
 

--- a/scripts/pull-build
+++ b/scripts/pull-build
@@ -1,1 +1,1 @@
-cabal update && git submodule update && cabal install . submodules/senza
+cabal update && cabal install .


### PR DESCRIPTION
The build instructions fail because there is no submodule called `submodules/senza` anymore.