### PR TITLE
changed example in "Try it" from foldr to map

### DIFF
--- a/static/js/tryhaskell.pages.js
+++ b/static/js/tryhaskell.pages.js
@@ -35,7 +35,7 @@ tryhaskell.pages.list =
          '<p>' +
          '<code title="Click me to insert &quot;23 * 36&quot; into the console." style="cursor: pointer;">23 * 36</code> or <code title="Click me to insert &quot;reverse ' +
          '&quot;hello&quot;&quot; into the console." style="cursor: pointer;">reverse ' +
-         '"hello"</code> or <code title="Click me to insert &quot;foldr (:) [] [1,2,3]&quot; into the console." style="cursor: pointer;">foldr (:) [] [1,2,3]</code> or <code title="Click me to insert." style="cursor: pointer;">do line <- getLine; putStrLn line</code> or <code>readFile "/welcome"</code>' +
+         '"hello"</code> or <code title="Click me to insert &quot;map (+1) [1,2,3]&quot; into the console." style="cursor: pointer;">foldr (:) [] [1,2,3]</code> or <code title="Click me to insert." style="cursor: pointer;">do line <- getLine; putStrLn line</code> or <code>readFile "/welcome"</code>' +
          '</p>' +
          '<p><a href="https://hackage.haskell.org/package/pure-io-0.2.0/docs/PureIO.html#g:2">These</a> IO actions are supported in this sandbox.</p>' +
          '</p>' +


### PR DESCRIPTION
The previous example with `foldr (:) [] [1,2,3]` was a bit obscure for newbies and did not bring much, since the result is the same as argument 3. Replaced with example with `map (+1)  [1,2,3]`, very readable even without knowing haskell and using partial application and higher order function.