### PR TITLE
Fix automatic PATH expansion in Linux setup guide

### DIFF
--- a/static/markdown/linux-install.md
+++ b/static/markdown/linux-install.md
@@ -10,7 +10,7 @@ Steps to setup:
     sudo apt-get update
     sudo apt-get install -y cabal-install-1.20 ghc-7.8.4
     cat >> ~/.bashrc <<EOF
-    export PATH=~/.cabal/bin:/opt/cabal/1.20/bin:/opt/ghc/7.8.4/bin:$PATH
+    export "PATH=~/.cabal/bin:/opt/cabal/1.20/bin:/opt/ghc/7.8.4/bin:\$PATH"
     EOF
     export PATH=~/.cabal/bin:/opt/cabal/1.20/bin:/opt/ghc/7.8.4/bin:$PATH
     cabal update


### PR DESCRIPTION
This way $PATH will get inserted as a variable, as currently it will get expanded by the shell and get hardcoded in `~/.bashrc`.