### PR TITLE
Change 'advanced purely-functional language' to 'general-purpose purely-functional language'

### DIFF
--- a/design/landing.svg
+++ b/design/landing.svg
@@ -1630,7 +1630,7 @@
            x="651"
            y="437"
            style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1" /></flowRegion><flowPara
-         id="flowPara8194-6">An advanced purely-functional programming language</flowPara></flowRoot>    <g
+         id="flowPara8194-6">A general-purpose purely-functional programming language</flowPara></flowRoot>    <g
        id="text2990-9-70-9"
        style="font-size:417.63537598px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient10298-2);fill-opacity:1;stroke:none;display:inline;filter:url(#filter10510);font-family:Haskell;-inkscape-font-specification:Haskell"
        clip-path="url(#clipPath3924-0-1-2-11-9)"
@@ -1775,7 +1775,7 @@
            x="651"
            y="437"
            style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1" /></flowRegion><flowPara
-         id="flowPara8194">An advanced purely-functional programming language</flowPara></flowRoot>    <flowRoot
+         id="flowPara8194">A general-purpose purely-functional programming language</flowPara></flowRoot>    <flowRoot
        xml:space="preserve"
        id="flowRoot8196"
        style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sawasdee;-inkscape-font-specification:Sawasdee"><flowRegion

--- a/hl.org
+++ b/hl.org
@@ -48,7 +48,7 @@ The F# Software Foundation exists to promote, protect, and advance F#,
 and to support and foster the growth of a diverse international
 community of F# users.
 **** Haskell.org
-Haskell is an advanced purely-functional programming language. An
+Haskell is a general-purpose purely-functional programming language. An
 open-source product of more than twenty years of cutting-edge
 research, it allows rapid development of robust, concise, correct
 software. With strong support for integration with other languages,

--- a/src/HL/View/Home.hs
+++ b/src/HL/View/Home.hs
@@ -49,7 +49,7 @@ header url =
   where branding =
           span_ [class_ "name",background url img_logo_png] "Haskell"
         summation =
-          span_ [class_ "summary"] "An advanced purely-functional programming language"
+          span_ [class_ "summary"] "A general-purpose purely-functional programming language"
         tag =
           span_ [class_ "tag"] "Declarative, statically typed code."
         sample =

--- a/static/markdown/home.md
+++ b/static/markdown/home.md
@@ -1,7 +1,7 @@
-Haskell is an advanced purely-functional programming language. An
-open-source product of more than twenty years of cutting-edge
-research, it allows rapid development of robust, concise, correct
-software. With strong support for integration with other languages,
-built-in concurrency and parallelism, debuggers, profilers, rich
-libraries and an active community, Haskell makes it easier to produce
-flexible, maintainable, high-quality software.
+Haskell is a general-purpose purely-functional programming
+language. An open-source product of more than twenty years of
+cutting-edge research, it allows rapid development of robust, concise,
+correct software. With strong support for integration with other
+languages, built-in concurrency and parallelism, debuggers, profilers,
+rich libraries and an active community, Haskell makes it easier to
+produce flexible, maintainable, high-quality software.


### PR DESCRIPTION
It'll give non-Haskell programmers a warmer first impression when they wander onto the site.