### PR TITLE
Remove quotes so tilde is expanded

### DIFF
--- a/static/markdown/linux-install.md
+++ b/static/markdown/linux-install.md
@@ -10,7 +10,7 @@ Steps to setup:
     sudo apt-get update
     sudo apt-get install -y cabal-install-1.20 ghc-7.8.4
     cat >> ~/.bashrc <<EOF
-    export PATH="~/.cabal/bin:/opt/cabal/1.20/bin:/opt/ghc/7.8.4/bin:\$PATH"
+    export PATH=~/.cabal/bin:/opt/cabal/1.20/bin:/opt/ghc/7.8.4/bin:\$PATH
     EOF
     export PATH=~/.cabal/bin:/opt/cabal/1.20/bin:/opt/ghc/7.8.4/bin:$PATH
     cabal update

--- a/static/markdown/linux-install.md
+++ b/static/markdown/linux-install.md
@@ -10,7 +10,7 @@ Steps to setup:
     sudo apt-get update
     sudo apt-get install -y cabal-install-1.20 ghc-7.8.4
     cat >> ~/.bashrc <<EOF
-    export PATH=~/.cabal/bin:/opt/cabal/1.20/bin:/opt/ghc/7.8.4/bin:\$PATH
+    export PATH="\$HOME/.cabal/bin:/opt/cabal/1.20/bin:/opt/ghc/7.8.4/bin:\$PATH"
     EOF
     export PATH=~/.cabal/bin:/opt/cabal/1.20/bin:/opt/ghc/7.8.4/bin:$PATH
     cabal update


### PR DESCRIPTION
Some applications (leksah, ghcjs, which, ...) cannot use a path if ~ is not expanded by bash.