### PR TITLE
Use 2015-08-05 MinGHC installers

### DIFF
--- a/static/markdown/windows-install.md
+++ b/static/markdown/windows-install.md
@@ -4,9 +4,9 @@ MinGHC is a minimal installer for GHC and cabal.
 
 * Download the Windows 7.8.4 installer here:
 
-[MinGHC installer (32-bit)](https://github.com/fpco/minghc/releases/download/2015-05-26/minghc-7.8.4-i386.exe)
+[MinGHC installer (32-bit)](https://github.com/fpco/minghc/releases/download/2015-08-05/minghc-7.8.4-i386.exe)
 
-[MinGHC installer (64-bit)](https://github.com/fpco/minghc/releases/download/2015-05-26/minghc-7.8.4-x86_64.exe)
+[MinGHC installer (64-bit)](https://github.com/fpco/minghc/releases/download/2015-08-05/minghc-7.8.4-x86_64.exe)
 
 * Other versions are available at the MinGHC homepage.
 


### PR DESCRIPTION
  * Includes `stack`
  * Fix bug when `PATH` gets really long

These links still point to 7.8.4. Are we ready to expose direct links to 7.10.2 yet?