### PR TITLE
Make stack the primary download method on the Downloads page

### DIFF
--- a/src/HL/View/Downloads.hs
+++ b/src/HL/View/Downloads.hs
@@ -9,17 +9,48 @@ import HL.Types
 import HL.View
 import HL.View.Template
 
+stackSection :: Html ()
+stackSection = do
+  h2_ "The stack build tool"
+  p_ $ do
+    a_ [href_ "https://github.com/commercialhaskell/stack#readme"] "stack"
+    " is a modern build tool for Haskell code. It handles the management of your toolchain (including the GHC compiler and MSYS2 on Windows), building and registering libraries, and much more."
+  p_ (a_ [href_ "https://github.com/commercialhaskell/stack/blob/master/GUIDE.md"] "Read the stack guide →")
+  p_ "Get stack for:"
+  ul_ $ do
+    li_ $ a_ [href_ "https://github.com/commercialhaskell/stack/wiki/Downloads#windows"] "Windows"
+    li_ $ a_ [href_ "https://github.com/commercialhaskell/stack/wiki/Downloads#os-x"] "OS X"
+    li_ $ a_ [href_ "https://github.com/commercialhaskell/stack/wiki/Downloads#ubuntu"] "Ubuntu"
+    li_ $ a_ [href_ "https://github.com/commercialhaskell/stack/wiki/Downloads#debian"] "Debian"
+    li_ $ a_ [href_ "https://github.com/commercialhaskell/stack/wiki/Downloads#centos--red-hat--amazon-linux)"] "CentOS / Red Hat / Amazon Linux"
+    li_ $ a_ [href_ "https://github.com/commercialhaskell/stack/wiki/Downloads#fedora"] "Fedora"
+    li_ $ a_ [href_ "https://github.com/commercialhaskell/stack/wiki/Downloads#nixos"] "NixOS"
+    li_ $ a_ [href_ "https://github.com/commercialhaskell/stack/wiki/Downloads#arch-linux"] "Arch Linux"
+    li_ $ a_ [href_ "https://github.com/commercialhaskell/stack/wiki/Downloads#linux"] "Linux (general)"
+  p_ (a_ [href_ "https://github.com/commercialhaskell/stack/wiki/Downloads#upgrade"] "Upgrade instructions")
+
+  h3_ "Installers including GHC"
+  -- Note: once Haskell Platform begins shipping with stack and without global
+  -- packages, it should take over this section.
+  p_ "If you're going to be installing Haskell on multiple systems, an installer that includes GHC may be beneficial to decrease bandwidth. The following options are available:"
+  ul_ $ do
+    li_ $ do
+      "Windows: "
+      a_ [href_ "https://github.com/fpco/minghc/releases"] "MinGHC"
+    li_ $ do
+      "OS X (10.9 or later): "
+      a_ [href_ "http://ghcformacosx.github.io/"] "GHC for Mac OS X"
+
 hpSection :: Html ()
 hpSection = do
   let hpRoot = "http://www.haskell.org/platform/"
-  h2_ "Haskell Platform"
+  h3_ "Haskell Platform"
   p_ $ "The Haskell Platform is a convenient way to install the Haskell development tools and"
        <> " a collection of commonly used Haskell packages from Hackage."
   p_ $ "Get the Haskell Platform for:"
   ul_ $ do li_ $ a_ [href_ $ hpRoot <> "windows.html"] "Windows"
            li_ $ a_ [href_ $ hpRoot <> "mac.html"] "OS X"
            li_ $ a_ [href_ $ hpRoot <> "linux.html"] "Linux"
-  hr_ [style_ "height: 1px; background-color: black;"]
 
 -- | Downloads view.
 downloadsV :: FromLucid App
@@ -30,15 +61,19 @@ downloadsV =
          (row_
             (span12_ [class_ "col-md-12"]
                (do h1_ "Downloads"
+                   stackSection
+                   libraries
+                   hr_ [style_ "height: 1px; background-color: black;"]
+                   h2_ "Alternative Toolchain Downloads"
                    hpSection
-                   h2_ "Compiler and base libraries"
+                   h3_ "Compiler and base libraries"
                    p_ "Many now recommend just using the compiler and base libraries combined with package sandboxing, especially for new users interested in using frameworks with complex dependency structures."
                    p_ "Downloads are available on a per operating system basis:"
                    ul_ (forM_ [minBound .. maxBound]
                               (\os ->
                                  li_ (a_ [href_ (url (DownloadsForR os))]
                                          (toHtml (toHuman os)))))
-                   thirdParty))))
+                   ))))
 
 -- | OS-specific downloads view.
 downloadsForV :: OS -> Html () -> Html () -> FromLucid App
@@ -58,56 +93,9 @@ downloadsForV os autoInstall manualInstall =
                             p_ "To install GHC and Cabal manually, follow these steps."
                             manualInstall)))))
 
-thirdParty :: Html ()
-thirdParty =
-  do h2_ "Third party libraries"
-     p_ (do "In Haskell, packages are managed with the Cabal package system built into GHC (and other compilers). "
-            "For more specific details, see "
-            (a_ [href_ "https://www.haskell.org/cabal/users-guide/"] "The Cabal User Guide")
-            ".")
-     hackage
-     ltsHaskell
-     stackage
-     github
-
-hackage :: Html ()
-hackage =
-  do h3_ "Hackage"
-     p_ (do "Hackage is a repository of packages to which anyone can freely \
-            \upload at any time. The packages are available immediately and \
-            \documentation will be generated and hosted there. It can be used by "
-            code_ "cabal install"
-            ".")
-     p_ "You can install a package by merely running: "
-     pre_ "$ cabal update \n\
-          \$ cabal install the-package"
+libraries :: Html ()
+libraries =
+  do h2_ "Libraries"
+     p_ $ do
+       "There are thousands of high quality libraries available for Haskell. You can browse them online on Hackage, Haskell's central open source package repository"
      p_ (a_ [href_ "https://hackage.haskell.org/packages/"] $ "Go to Hackage →")
-
-ltsHaskell :: Html ()
-ltsHaskell =
-  do h3_ "LTS Haskell"
-     p_ "LTS Haskell is a stackage-based long-term support set of packages \
-        \which build and pass tests together, with backported bug fixes."
-     p_ (a_ [href_ "http://www.stackage.org/lts"] $ "Get LTS Haskell →")
-
-stackage :: Html ()
-stackage =
-  do h3_ "Stackage Nightly"
-     p_ "Stackage is a nightly generated stable repository of snapshots of package sets in \
-        \which only packages which build and pass tests together are bundled \
-        \together into a snapshot."
-     p_ (a_ [href_ "http://www.stackage.org/nightly"] $ "Get Stackage Nightly →")
-
-github :: Html ()
-github =
-  do h3_ "From source control repositories"
-     p_ "Installing from a source repository is also possible. For example, \
-        \to clone and install the network package from source, you would run:"
-     pre_ "$ git clone git@github.com:haskell/network.git\n\
-          \$ cabal install network/"
-     p_ "Or:"
-     pre_ "$ git clone git@github.com:haskell/network.git\n\
-          \$ cd network\n\
-          \$ cabal install"
-     p_ (a_ [href_ "https://github.com/trending?l=haskell&since=monthly"] $
-            "Browse Github by Haskell repositories →")


### PR DESCRIPTION
This pull request makes the primary download information on haskell.org refer
to stack. Motivations:

* In its current form, most Haskell tutorials online warn users away from using the Haskell Platform, due to issues with the global package database containing too many packages.
* Linux distribution packages contain out-of-date GHC versions which cause trouble more often than not.
* stack's curation-by-default is absolutely the right thing for new users, and this downloads page *must* cater to new users.
* There is no official (or perhaps even unofficial) guide to using cabal the right way, and the default behavior drops users into dependency hell too often. Again: we need to cater to new users, and telling them "download this tool, but then use an undocumented workflow to make it work" is not appropriate.

If in the future these facts change (Haskell Platform ships without additional
global pacakges, cabal has a more user-friendly default-settings story, etc),
we should revisit, but for now, stack is the best option.

I'm hoping that the discussion on this pull request avoids the standard
rhetorical (and false) arguments about "standard tooling" and "community
tooling." As to the best critique I know of stack: yes, stack is relatively
young tooling. Nonetheless, in its current state, new users experience less
problems with it than any other configuration I'm aware of.

All points raised above have plenty of sources online to back them up, but I
think everyone reading this is aware of those, so it's not worthwhile to
overload this already long description with lots of sources to read.