### PR TITLE
Add Seattle Area Haskell Users' Group link

### DIFF
--- a/src/HL/View/Community.hs
+++ b/src/HL/View/Community.hs
@@ -61,6 +61,7 @@ offline =
      li_ (a_ [href_ "http://ChicagoHaskell.com/"] "Chicago Haskell")
      li_ (a_ [href_ "http://www.meetup.com/NY-Haskell/"] "New York Haskell Users Group")
      li_ (a_ [href_ "http://www.meetup.com/London-Haskell/"] "London Haskell")
+     li_ (a_ [href_ "http://www.meetup.com/seahug/"] "Seattle Area Haskell Users' Group")
      li_ (a_ [href_ "http://www.meetup.com/find/?allMeetups=true&keywords=Haskell&radius=Infinity"] "More Haskell meetups at meetup.com")
 
 academicConferences :: Html ()


### PR DESCRIPTION
Add Seattle Area Haskell Users' Group link to Community page