### PR TITLE
Use plain HTTP for Haskell Stack links

### DIFF
--- a/static/markdown/downloads-main.md
+++ b/static/markdown/downloads-main.md
@@ -89,13 +89,13 @@ Windows), building and registering libraries, and more.
 
 ### How to get it
 
-The [install and upgrade page](https://docs.haskellstack.org/en/stable/install_and_upgrade/)
+The [install and upgrade page](http://docs.haskellstack.org/en/stable/install_and_upgrade/)
 describes how to download Stack on various platforms, although the main
 three are repeated here:
 
-- [Ubuntu Linux](https://docs.haskellstack.org/en/stable/install_and_upgrade/#ubuntu)
-- [OS X](https://docs.haskellstack.org/en/stable/install_and_upgrade/#os-x)
-- [Windows](https://docs.haskellstack.org/en/stable/install_and_upgrade/#windows)
+- [Ubuntu Linux](http://docs.haskellstack.org/en/stable/install_and_upgrade/#ubuntu)
+- [OS X](http://docs.haskellstack.org/en/stable/install_and_upgrade/#os-x)
+- [Windows](http://docs.haskellstack.org/en/stable/install_and_upgrade/#windows)
 
 Instructions for other Linux distributions, including Debian, Fedora, Red Hat,
 Nix OS, and Arch Linux, are also available.
@@ -108,7 +108,7 @@ For help with Haskell and GHC in general, see the links mentioned
 - The [README](https://github.com/commercialhaskell/stack/#readme) offers a
   general overview, and help with installation.
 - There is an
-  [in-depth guide](https://docs.haskellstack.org)
+  [in-depth guide](http://docs.haskellstack.org)
   to using Stack.
 - [Getting started with Stack](http://seanhess.github.io/2015/08/04/practical-haskell-getting-started.html)
   introduces how to build new projects using Stack.
@@ -138,7 +138,7 @@ broader set of globally installed libraries.
   new packages, and by default fetches from
   [Hackage](https://hackage.haskell.org/), the central Haskell package
   repository.
-- the [Stack](https://docs.haskellstack.org) tool for developing projects
+- the [Stack](http://docs.haskellstack.org) tool for developing projects
 - Support for profiling and code coverage analysis
 - 35 core & widely-used [packages](https://www.haskell.org/platform/contents.html)
 


### PR DESCRIPTION
 - docs.haskellstack.org doesn't have valid TLS cert so visitors will get an error

 - readthedocs.com supports custom TLS, but it isn't configured or is broken for docs.haskellstack.org