### PR TITLE
Add Haskell-community to mailing-list.md.

### DIFF
--- a/static/markdown/mailing-lists.md
+++ b/static/markdown/mailing-lists.md
@@ -32,6 +32,16 @@ discussions. Any newbie question is welcome.
 
 [Archives](http://mail.haskell.org/pipermail/beginners/)
 
+## Haskell Community
+
+Discussions and feedback regarding planned and/or upcoming
+community-related decisions. Subscribe if you want to be in the know
+and participate in the decision-making process of the haskell.org committee.
+
+[Subscribe now →](http://mail.haskell.org/cgi-bin/mailman/listinfo/haskell-community)
+
+[Archives](https://mail.haskell.org/pipermail/haskell-community/)
+
 ## Other mailing lists
 
 There are many lists hosted on haskell.org, though be warned some are


### PR DESCRIPTION
So given the current climate, I thought it might be worth it to add the Haskell-community mailing list to the Mailing List page of the site. Right now it's pretty obscure and if it's to be useful to the wider community, then it should have a more prominent position than it currently has as to communicate that it's actually used for pretty significant decision-making and if you want to be involved in said decisions, you should sign up.

Let me know if there's any improvements I can make.