### PR TITLE
2016 => 2017

### DIFF
--- a/src/HL/View/Template.hs
+++ b/src/HL/View/Template.hs
@@ -156,7 +156,7 @@ footer url _r =
   where hlCopy =
           do container_
                        (row_ (do span3_ [class_ "col-sm-4 col-md-3"]
-                                        (span_ [class_ "item"] "\169 2014\8211\&2016 haskell.org")
+                                        (span_ [class_ "item"] "\169 2014\8211\&2017 haskell.org")
                                  span12_ [class_ "col-xs-12 visible-xs"] (br_ [])
                                  span8_ [class_ "col-sm-4 col-md-6 text-center"]
                                         (do br_ [class_ "visible-xs"]


### PR DESCRIPTION
Update the copyright text for the new year, from "© 2014–2016 haskell.org" to "© 2014–2017 haskell.org".