### PR TITLE
BayHac link to wiki

### DIFF
--- a/src/HL/View/Community.hs
+++ b/src/HL/View/Community.hs
@@ -89,7 +89,7 @@ commercialConferences =
 
 hackathons :: Html ()
 hackathons =
-  do li_ (a_ [href_ "http://bayhac.org/"] "BayHac (Bay Area, USA)")
+  do li_ (a_ [href_ "https://wiki.haskell.org/BayHac"] "BayHac (San Francisco Bay Area, CA, USA)")
      li_ (a_ [href_ "https://wiki.haskell.org/Hac_Phi"] "Hac Phi (Philadelphia, PA, USA)")
      li_ (a_ [href_ "https://wiki.haskell.org/ZuriHac"] "ZuriHac (Zurich, CH)")
 


### PR DESCRIPTION
Still working on taking over the BayHac website. The wiki is a better place to reference BayHac right now.