### PR TITLE
Add haskell-jp (Japan Haskell Users Group)

### DIFF
--- a/src/HL/View/Community.hs
+++ b/src/HL/View/Community.hs
@@ -62,6 +62,7 @@ offline =
      li_ (a_ [href_ "http://www.meetup.com/berlinhug/"] "Berlin Haskell Users Group")
      li_ (a_ [href_ "http://ChicagoHaskell.com/"] "Chicago Haskell")
      li_ (a_ [href_ "http://www.haskell-ita.it/"] "Italy Haskell Users Group")
+     li_ (a_ [href_ "http://haskell.jp/"] "Japan Haskell Users Group (Haskell-jp)")
      li_ (a_ [href_ "http://www.meetup.com/NY-Haskell/"] "New York Haskell Users Group")
      li_ (a_ [href_ "http://www.meetup.com/London-Haskell/"] "London Haskell")
      li_ (a_ [href_ "http://www.meetup.com/seahug/"] "Seattle Area Haskell Users' Group")


### PR DESCRIPTION
Please merge `Community.hs` to add link of haskell-jp.
Thank you.
