### PR TITLE
Make downloads page as simple as possible

### DIFF
--- a/config/routes
+++ b/config/routes
@@ -3,6 +3,7 @@
 /donate DonateR GET
 /downloads DownloadsR GET
 /downloads/#OS DownloadsForR GET
+/packages PackagesR GET
 /community CommunityR GET
 /irc IrcR GET
 /mailing-lists MailingListsR GET

--- a/src/HL/Controller/Packages.hs
+++ b/src/HL/Controller/Packages.hs
@@ -1,0 +1,14 @@
+-- | Packages page controller.
+
+module HL.Controller.Packages where
+
+import HL.Controller
+import HL.View.Packages
+import HL.Model.Markdown
+import HL.View
+
+-- | Packages controller.
+
+getPackagesR :: C (Html ())
+getPackagesR =
+  lucid . packagesFromMarkdown =<< io (getMarkdown "packages-main.md")

--- a/src/HL/Dispatch.hs
+++ b/src/HL/Dispatch.hs
@@ -13,6 +13,7 @@ import HL.Controller.Community
 import HL.Controller.Documentation
 import HL.Controller.Donate
 import HL.Controller.Downloads
+import HL.Controller.Packages
 import HL.Controller.Home
 import HL.Controller.Irc
 import HL.Controller.MailingLists
@@ -21,3 +22,4 @@ import HL.Foundation
 import Yesod.Core.Dispatch
 
 mkYesodDispatch "App" resourcesApp
+

--- a/src/HL/Foundation.hs
+++ b/src/HL/Foundation.hs
@@ -62,6 +62,7 @@ instance Human (Route App) where
       StaticR{}            -> "Static"
       DownloadsR           -> "Downloads"
       DownloadsForR os     -> "Downloads for " <> toHuman os
+      PackagesR           -> "Packages"
 
 instance Slug (Route App) where
   toSlug r =
@@ -76,3 +77,7 @@ instance Slug (Route App) where
       StaticR{}         -> "static"
       DownloadsR        -> "downloads"
       DownloadsForR{}   -> "downloads"
+      PackagesR        -> "packages"
+
+
+

--- a/src/HL/View/Packages.hs
+++ b/src/HL/View/Packages.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Packages page view.
+
+module HL.View.Packages where
+
+import HL.Types
+import HL.View
+import HL.View.Template
+
+packagesFromMarkdown :: Html () -> FromLucid App
+packagesFromMarkdown md = template
+  []
+  "Packages"
+  ( \_ -> container_
+    ( row_
+      ( span12_
+        [class_ "col-sm-12"]
+        ( do
+          h1_ (toHtml ("Packages" :: String))
+          md
+        )
+      )
+    )
+  )
+

--- a/src/HL/View/Template.hs
+++ b/src/HL/View/Template.hs
@@ -119,7 +119,7 @@ navigation showBrand crumbs mroute url =
   where items =
           div_ [class_ "collapse navbar-collapse", id_ "haskell-menu"]
                (ul_ [class_ "nav navbar-nav navbar-right"]
-                    (mapM_ item [DownloadsR,CommunityR,DocumentationR,NewsR]))
+                    (mapM_ item [DownloadsR,PackagesR,CommunityR,DocumentationR,NewsR]))
           where item :: Route App -> Html ()
                 item route =
                   li_ [class_ "active" | Just route == mroute || elem route crumbs]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,3 @@
-resolver: lts-6.30
+resolver: lts-10.1
+extra-deps:
+  - spoon-0.3.1

--- a/static/markdown/downloads-main.md
+++ b/static/markdown/downloads-main.md
@@ -1,27 +1,21 @@
-There are three widely used ways to install the Haskell toolchain on supported
-platforms. These are:
+<h3 style="text-align:center;">The most popular way to get Haskell is either by using it through <a href="https://docs.haskellstack.org/en/stable/README/">Stack</a> or by downloading the <a href="https://www.haskell.org/platform/">Haskell Platform</a>.</h3>
 
-- [Minimal installers](#minimal): Just GHC (the compiler), and build
-  tools (primarily Cabal and Stack) are installed globally on your system, using your
-  system's package manager.
+<br>
 
-- [Stack](#stack): Installs the `stack` command globally: a project-centric
-  build tool to automatically download and manage Haskell dependencies on a
-  project-by-project basis.
+<div style="text-align:center;">
+  <a href="https://docs.haskellstack.org/en/stable/README/">
+    <button type="button" class="btn btn-lg btn-primary">Download Stack</button>
+  </a>
+  <a href="https://www.haskell.org/platform/">
+    <button type="button" class="btn btn-lg btn-primary">Download Haskell Platform</button>
+  </a>
+</div>
 
-- [Haskell Platform](#platform): Installs GHC, Cabal, and some other tools,
-  along with a starter set of libraries in a global location on your system.
+<br>
 
-These options make different choices as to what is installed globally on your
-system and what is maintained in project-specific environments. Global
-installations allow more sharing across users and projects, but at the cost of
-potential conflicts between projects. To avoid these conflicts, each option
-has a lightweight *sandboxing* feature that creates largely self-contained,
-per-project environments. With Minimal you can optionally sandbox the
-libraries, avoiding most conflicts. Stack sandboxes the compiler, tools and
-libraries, so avoids nearly all kinds of conflicts between projects. With
-Platform you can also optionally sandbox libraries, but not the globally
-installed platform libraries.
+<p style="text-align:center;">On linux and looking for alternative ways of installing Haskell? <a href="/downloads/linux">Click here.</a></p>
+
+<hr style="height: 1px; background-color: black;" --/>
 
 ### Haskell IDEs & other distributions
 
@@ -32,175 +26,4 @@ The Haskell Wiki contains a [list of the most popular ones](https://wiki.haskell
 <!-- For information on other platforms and methods, please see the section on
 [third party installers](#other). -->
 
-<hr style="height: 1px; background-color: black;" --/>
-
-## Minimal installers
-
-### What they are <a name="minimal"></a>
-
-Minimal installers provide centrally the
-[GHC](https://www.haskell.org/ghc)  compiler and the
-[Cabal](https://www.haskell.org/cabal/) and
-[Stack](https://github.com/commercialhaskell/stack) tools for
-installing packages. Some may install further build tools (i.e. for
-parsing and lexing) as well.
-
-### What you get
-
-- Only the core libraries necessary for each platform are included.
-- Cabal or Stack must be used to download and install packages after installation.
-
-### How to get them
-
-- [Linux](/downloads/linux)
-- [OS X](https://www.haskell.org/platform/mac.html) (via the minimal platform)
-- [Windows](https://www.haskell.org/platform/windows.html) (via
-  the minimal platform)
-
-### Where to get help <a name="help" />
-
-- For help learning Haskell itself, start with the  [Documentation](https://www.haskell.org/documentation) page on the [Haskell Wiki](https://wiki.haskell.org/).
-- If you need help with [GHC](https://www.haskell.org/ghc)---the Haskell
-  compiler---there is a comprehensive
-  [GHC User Manual](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/index.html).
-- For help using Cabal to download or create additional packages (see
-  [below](#libraries)), there is the
-  [Cabal User Guide](https://www.haskell.org/cabal/users-guide/).
-- For help using Stack to download or create packages, see the stack documentation [below](#stackhelp).
-- Finally, you can ask questions of other Haskell users and experts on the
-  [\#haskell IRC channel](irc://irc.freenode.net/haskell) on the Freenode IRC
-  network.
-
-## Stack
-
-### What it is <a name="stack"></a>
-
-Stack is a cross-platform build tool for Haskell that
-handles management of the toolchain (including the GHC compiler and MSYS2 on
-Windows), building and registering libraries, and more.
-
-### What you get
-
-- Once downloaded, it has the capacity to download and install GHC and other
-  core tools.
-- Project development is isolated within sandboxes, including automatic
-  download of the right version of GHC for a given project.
-- It manages all Haskell-related dependencies, ensuring reproducible builds.
-- It fetches from a curated repository of over a thousand packages by default,
-  known to be mutually compatible.
-- It can optionally use Docker to produce standalone deployments.
-
-### How to get it
-
-The [install and upgrade page](http://docs.haskellstack.org/en/stable/install_and_upgrade/)
-describes how to download Stack on various platforms, although the main
-three are repeated here:
-
-- [Ubuntu Linux](http://docs.haskellstack.org/en/stable/install_and_upgrade/#ubuntu)
-- [OS X](http://docs.haskellstack.org/en/stable/install_and_upgrade/#os-x)
-- [Windows](http://docs.haskellstack.org/en/stable/install_and_upgrade/#windows)
-
-Instructions for other Linux distributions, including Debian, Fedora, Red Hat,
-Nix OS, and Arch Linux, are also available.
-
-### Where to get help <a name="stackhelp"></a>
-
-For help with Haskell and GHC in general, see the links mentioned
-[above](#help). For Stack itself there are also the following resources:
-
-- The [README](https://github.com/commercialhaskell/stack/#readme) offers a
-  general overview, and help with installation.
-- There is an
-  [in-depth guide](http://docs.haskellstack.org)
-  to using Stack.
-- [Getting started with Stack](http://seanhess.github.io/2015/08/04/practical-haskell-getting-started.html)
-  introduces how to build new projects using Stack.
-- You may post issues and feature requests on its
-  [GitHub issue tracker](https://github.com/commercialhaskell/stack).
-- There is a [mailing list for Stack](https://groups.google.com/d/forum/haskell-stack)
-- There is a dedicated
-  [\#haskell-stack IRC channel](irc://irc.freenode.net/haskell-stack) on the
-  Freenode IRC network.
-- The [StackOverflow haskell-stack tag](http://stackoverflow.com/questions/tagged/haskell-stack)
-  has many stack-specific questions and answers.
-
-## Haskell Platform
-
-### What it is
-
-<a name="platform"></a>The Haskell Platform is a self-contained, all-in-one
-installer. After download, you will have everything necessary to build Haskell
-programs against a core set of useful libraries. It comes in both minimal versions
-with tools but no libraries outside of GHC core, or full versions, which include a
-broader set of globally installed libraries.
-
-### What you get
-
-- The [Glasgow Haskell Compiler](https://www.haskell.org/ghc)
-- The [Cabal build system](https://www.haskell.org/cabal/), which can install
-  new packages, and by default fetches from
-  [Hackage](https://hackage.haskell.org/), the central Haskell package
-  repository.
-- the [Stack](http://docs.haskellstack.org) tool for developing projects
-- Support for profiling and code coverage analysis
-- 35 core & widely-used [packages](https://www.haskell.org/platform/contents.html)
-
-### How to get it
-
-The Platform is provided as a single installer, and can be downloaded at the
-links below.
-
-- [Linux](http://www.haskell.org/platform/linux.html)
-- [OS X](http://www.haskell.org/platform/mac.html)
-- [Windows](http://www.haskell.org/platform/windows.html)
-
-### Where to get help
-
-- You can find a comprehensive list of
-  [what the Platform offers](https://www.haskell.org/platform/contents.html).
-- See the general help mentioned [above](#help), which covers the usage of GHC,
-as well as the Cabal and Stack tools.
-
-<hr style="height: 1px; background-color: black;" --/>
-
-## Additional Libraries <a name='libraries'></a>
-
-In Haskell, packages are configured and built with the Cabal package system built into GHC (and other compilers). For more specific details, see [The Cabal User Guide](https://www.haskell.org/cabal/users-guide/). The command line tools to download and install packages are either `cabal` or `stack`, each having different workflows. For details on their usage, see the documentation above.
-
-### Hackage
-
-Hackage is a repository of packages to which anyone can freely upload at any time. The packages are available immediately and documentation will be generated and hosted there. It can be used by cabal install.
-
-You can install a package using cabal by running:
-
-    $ cabal update
-    $ cabal install the-package
-
-Note that if you are not in a sandbox, this will install the package globally, which is often not what you want, so it is recommended to set up sandboxes in your project directory by running `cabal sandbox init`.
-
-[Go to Hackage →](https://hackage.haskell.org/packages/)
-
-### LTS Haskell
-
-LTS Haskell is a stackage-based long-term support set of packages which build and pass tests together, with backported bug fixes.
-
-[Get LTS Haskell →](http://www.stackage.org/lts)
-
-### Stackage Nightly
-
-Stackage is a nightly generated stable repository of snapshots of package sets in which only packages which build and pass tests together are bundled together into a snapshot.
-
-[Get Stackage Nightly →](http://www.stackage.org/nightly)
-
-### From source control repositories
-
-Installing from a source repository is also possible. For example, to clone and install the network package from source, you would run:
-
-    $ git clone https://github.com/haskell/network
-    $ cabal install network/
-
-Or:
-
-    $ git clone https://github.com/haskell/network
-    $ cd network
-    $ cabal install
+<br>

--- a/static/markdown/packages-main.md
+++ b/static/markdown/packages-main.md
@@ -1,0 +1,41 @@
+In Haskell, packages are configured and built with the Cabal package system built into GHC (and other compilers). For more specific details, see [The Cabal User Guide](https://www.haskell.org/cabal/users-guide/). The command line tools to download and install packages are either `cabal` or `stack`, each having different workflows. For details on their usage, see the documentation above.
+
+### Hackage
+
+Hackage is a repository of packages to which anyone can freely upload at any time. The packages are available immediately and documentation will be generated and hosted there. It can be used by cabal install.
+
+You can install a package using cabal by running:
+
+    $ cabal update
+    $ cabal install the-package
+
+Note that if you are not in a sandbox, this will install the package globally, which is often not what you want, so it is recommended to set up sandboxes in your project directory by running `cabal sandbox init`.
+
+[Go to Hackage →](https://hackage.haskell.org/packages/)
+
+### LTS Haskell
+
+LTS Haskell is a stackage-based long-term support set of packages which build and pass tests together, with backported bug fixes.
+
+[Get LTS Haskell →](http://www.stackage.org/lts)
+
+### Stackage Nightly
+
+Stackage is a nightly generated stable repository of snapshots of package sets in which only packages which build and pass tests together are bundled together into a snapshot.
+
+[Get Stackage Nightly →](http://www.stackage.org/nightly)
+
+### From source control repositories
+
+Installing from a source repository is also possible. For example, to clone and install the network package from source, you would run:
+
+    $ git clone https://github.com/haskell/network
+    $ cabal install network/
+
+Or:
+
+    $ git clone https://github.com/haskell/network
+    $ cd network
+    $ cabal install
+
+<br>


### PR DESCRIPTION
There are several things I've noticed with the current [downloads page](https://www.haskell.org/downloads) that can act as a deterrent to users getting Haskell up and running as quickly as possible:

- The page is incredibly confusing from the get-go. It's not immediately obvious how to get Haskell from any of the ways mentioned.
- There's way too much information that we expect a user to ingest before they can even start using Haskell. Most users who visit this page are looking for the easiest way to get up and running with Haskell. Why inundate them with information about sandboxing and global installations when they haven't even had a chance to write a hello world program in Haskell?
- A description of each of the three methods of installation at the top of the page are mentioned again in each respective section. So why bother describing it at the top?
- The only benefit provided by the "minimal installer" section is a link to the [linux page](https://www.haskell.org/downloads/linux). The other two links for osx and windows take you to the Haskell platform.

Rather than trying to squeeze as much information as possible into a single page, I've opted for a much simpler approach of showing the user where to get Haskell quickly. If the user wants to know more about the particular method they've chosen, then its all on the page that they just clicked into. Here's what it looks like (I took some inspiration from [Scala's download page](https://www.scala-lang.org/download/)):

![image](https://user-images.githubusercontent.com/6578679/34415620-c0940a54-ebbd-11e7-8f87-4452ab2c4da7.png)

I've also moved the unrelated "Additional Libraries" section into its own page called "Packages".

![image](https://user-images.githubusercontent.com/6578679/34415754-64434fde-ebbe-11e7-8520-a107f834684b.png)

Let me know what you think.


