### PR TITLE
Updated copyright 2017 => 2018

### DIFF
--- a/src/HL/View/Template.hs
+++ b/src/HL/View/Template.hs
@@ -156,7 +156,7 @@ footer url _r =
   where hlCopy =
           do container_
                        (row_ (do span3_ [class_ "col-sm-4 col-md-3"]
-                                        (span_ [class_ "item"] "\169 2014\8211\&2017 haskell.org")
+                                        (span_ [class_ "item"] "\169 2014\8211\&2018 haskell.org")
                                  span12_ [class_ "col-xs-12 visible-xs"] (br_ [])
                                  span8_ [class_ "col-sm-4 col-md-6 text-center"]
                                         (do br_ [class_ "visible-xs"]


### PR DESCRIPTION
This is similar to a change made last year (https://github.com/haskell-infra/hl/pull/190/commits/3fe25c0774b1882fa5fd09e7204316d544531ca5).

This changes the copyright text from "© 2014–2017 haskell.org" to "© 2014–2018 haskell.org".