### PR TITLE
Update Seattle Area Haskell Users' Group link

### DIFF
--- a/src/HL/View/Community.hs
+++ b/src/HL/View/Community.hs
@@ -67,7 +67,7 @@ offline =
      li_ (a_ [href_ "http://haskell.jp/"] "Japan Haskell Users Group (Haskell-jp)")
      li_ (a_ [href_ "http://www.meetup.com/NY-Haskell/"] "New York Haskell Users Group")
      li_ (a_ [href_ "http://www.meetup.com/London-Haskell/"] "London Haskell")
-     li_ (a_ [href_ "http://www.meetup.com/seahug/"] "Seattle Area Haskell Users' Group")
+     li_ (a_ [href_ "http://seattlehaskell.org/"] "Seattle Area Haskell Users' Group (SeaHUG)")
      li_ (a_ [href_ "http://www.meetup.com/find/?allMeetups=true&keywords=Haskell&radius=Infinity"] "More Haskell meetups at meetup.com")
 
 academicConferences :: Html ()


### PR DESCRIPTION
We have a spiffy new web site at http://seattlehaskell.org/. I would like the Community page to link to this.