### PR TITLE
Make links stand out from regular text

### DIFF
--- a/static/css/hl.css
+++ b/static/css/hl.css
@@ -268,7 +268,7 @@ textarea {
   line-height: inherit; }
 
 a {
-  color: #5d4f85;
+  color: #5d4fe5;
   text-decoration: none; }
   a:hover, a:focus {
     color: #3b3255;


### PR DESCRIPTION
Currently the links on https://www.haskell.org/downloads are black with
a very slight purple tint, making them hard to differentiate from regular
text. This change lets you see what's clickable and what isn't.