### PR TITLE
Remove version from cabal/ghc package names

### DIFF
--- a/static/markdown/linux-install.md
+++ b/static/markdown/linux-install.md
@@ -8,7 +8,7 @@ Steps to setup ghc and cabal:
     sudo apt-get install -y software-properties-common
     sudo add-apt-repository -y ppa:hvr/ghc
     sudo apt-get update
-    sudo apt-get install -y cabal-install-1.22 ghc-7.10.3
+    sudo apt-get install -y cabal-install ghc
     cat >> ~/.bashrc <<EOF
     export PATH="\$HOME/.cabal/bin:/opt/cabal/1.22/bin:/opt/ghc/7.10.3/bin:\$PATH"
     EOF


### PR DESCRIPTION
I just installed cabal-install and ghc on Ubuntu 18.04 and did not need the version suffixes on the package names.

Also the `PATH` setting looks wrong, as it has older version numbers hard-coded in it, but I'm not sure what the correct values are yet, so will defer that to a future PR.