### PR TITLE
Add 'Get Programming with Haskell' to book list

### DIFF
--- a/src/HL/View/Documentation.hs
+++ b/src/HL/View/Documentation.hs
@@ -44,7 +44,8 @@ books =
       ,("Programming in Haskell","http://www.cs.nott.ac.uk/~pszgmh/pih.html")
       ,("Haskell: The Craft of Functional Programming","http://www.haskellcraft.com/craft3e/Home.html")
       ,("The Haskell School of Music","http://haskell.cs.yale.edu/wp-content/uploads/2015/03/HSoM.pdf")
-      ,("Developing Web Applications with Haskell and Yesod","http://www.yesodweb.com/book")]
+      ,("Developing Web Applications with Haskell and Yesod","http://www.yesodweb.com/book")
+      ,("Get Programming with Haskell","https://www.manning.com/books/get-programming-with-haskell")]
 
 courses :: Html ()
 courses =


### PR DESCRIPTION
This commit is based on #227, but with an erroneous `]` removed.